### PR TITLE
add test_011b, US_55

### DIFF
--- a/pages/Elements/PageInstrumentLongPositionGoToPlatformButton.py
+++ b/pages/Elements/PageInstrumentLongPositionGoToPlatformButton.py
@@ -8,6 +8,7 @@ from pages.base_page import BasePage
 from pages.common import Common
 from pages.Elements.AssertClass import AssertClass
 from pages.Elements.testing_elements_locators import PageTradingInstrumentMarketsLocators
+from pages.Elements.testing_elements_locators import TradeCFDLocators
 
 
 class PageInstrumentLongPositionGoToPlatformButton(BasePage):
@@ -19,7 +20,7 @@ class PageInstrumentLongPositionGoToPlatformButton(BasePage):
         # page_signup_login = SignupLogin(d, cur_item_link)
         # page_signup_login.check_popup_signup_form()
         #
-        self.element_act_v2()
+        trade_instrument = self.element_act_v2()
 
         test_element = AssertClass(d, cur_item_link, self.bid)
         match cur_role:
@@ -28,7 +29,8 @@ class PageInstrumentLongPositionGoToPlatformButton(BasePage):
             case "NoAuth":
                 test_element.assert_login(d, cur_language, cur_item_link)
             case "Auth":
-                test_element.assert_trading_platform_v4(d, cur_item_link)
+                test_element.assert_trading_platform_v4(d, cur_item_link, tpd=False, tpi=True,
+                                                        trade_instrument=trade_instrument)
         self.driver.get(cur_item_link)
 
     def arrange_v2(self, d, cur_item_link):
@@ -57,6 +59,10 @@ class PageInstrumentLongPositionGoToPlatformButton(BasePage):
     def element_act_v2(self):
         print(f"\n{datetime.now()}   2. Act_v2")
         print(f"{datetime.now()}   LONG_POSITION_OVERNIGHT_FEE open =>")
+
+        trade_instrument = self.driver.find_element(*TradeCFDLocators.ITEM_NAME).text.split(' Spot')[0]
+        print(f"{datetime.now()}   TRADE_INSTRUMENT IS: {trade_instrument}")
+
         tool_info = self.driver.find_elements(*PageTradingInstrumentMarketsLocators.LONG_POSITION_OVERNIGHT_FEE)
         ActionChains(self.driver) \
             .move_to_element(tool_info[0]) \
@@ -87,3 +93,4 @@ class PageInstrumentLongPositionGoToPlatformButton(BasePage):
 
         button_go_to_platform.click()
         print(f"{datetime.now()} => BUTTON_GO_TO_PLATFORM clicked")
+        return trade_instrument

--- a/pytest.ini
+++ b/pytest.ini
@@ -71,6 +71,7 @@ markers =
     test_010:
     test_011:
     test_011a:
+    test_011b:
     test_012:
     test_013:
     test_014:

--- a/tests/US_55_ReTestsManual/artemdashkov/US_55-artemdashkov_ReTestsManual_test.py
+++ b/tests/US_55_ReTestsManual/artemdashkov/US_55-artemdashkov_ReTestsManual_test.py
@@ -11,6 +11,7 @@ from pages.common import Common
 from pages.Elements.ContentsBlockLearnMoreAboutUsLink import ContentsBlockLearnMoreAboutUsLink
 from pages.Elements.TradePageAddToFavoriteButton import TradePageAddToFavoriteButton
 from pages.Elements.WhyChooseBlockTryNowButtonInContent import WhyChooseBlockTryNowButtonInContent
+from pages.Elements.PageInstrumentLongPositionGoToPlatformButton import PageInstrumentLongPositionGoToPlatformButton
 from src.src import CapitalComPageSrc
 from pages.build_dynamic_arg import build_dynamic_arg_for_us_55
 from pages.conditions import Conditions
@@ -129,3 +130,49 @@ class TestManualDetected:
 
         test_element = TradePageAddToFavoriteButton(d, cur_item_link, bid)
         test_element.full_test(d, cur_language, cur_country, cur_role, cur_item_link, cur_market)
+
+    @allure.step("Start test of button [Go to platform] on tooltip 'Long position overnight fee'")
+    @pytest.mark.parametrize('cur_language', ["", "ar", "de", "el", "es", "fr", "it", "hu", "nl", "pl", "ru", "cn", "ro", "zh"])
+    @pytest.mark.parametrize('cur_country', ['de', 'au', 'ae'])
+    @pytest.mark.parametrize('cur_role', ["Auth"])
+    @pytest.mark.parametrize('cur_market', ["Shares", "Forex", "Indices", "Commodities", "Cryptocurrencies"])
+    @pytest.mark.test_011b
+    def test_011b_add_to_favourite_button_on_tooltip_long_position_overnight_fee(
+            self, worker_id, d, cur_language, cur_country, cur_role, cur_login, cur_password, cur_market):
+        """
+        Check: Button [Go to platform] on tooltip 'Long position overnight fee'
+        Language: All.
+        License: Not FCA
+        """
+
+        bid = build_dynamic_arg_for_us_55(
+            d, worker_id, cur_language, cur_country, cur_role,
+            "55", "ReTests of Manual Detected Bugs",
+            "011b",
+            "Testing button [Go to platform] on tooltip 'Long position overnight fee'",
+            False, False
+        )
+
+        page_conditions = Conditions(d, "")
+        link = page_conditions.preconditions(
+            d, CapitalComPageSrc.URL, "", cur_language, cur_country, cur_role, cur_login, cur_password)
+
+        menu = MenuSection(d, link)
+        match cur_market:
+            case "Shares":
+                cur_item_link = menu.open_shares_market_menu(d, cur_language, cur_country, link)
+            case "Forex":
+                cur_item_link = menu.open_forex_markets_menu(d, cur_language, cur_country, link)
+            case "Indices":
+                cur_item_link = menu.open_indices_markets_menu(d, cur_language, cur_country, link)
+            case "Commodities":
+                cur_item_link = menu.open_commodities_markets_menu(d, cur_language, cur_country, link)
+            case "Cryptocurrencies":
+                cur_item_link = menu.open_cryptocurrencies_market_menu(d, cur_language, cur_country, link)
+
+        test_element = TradePageAddToFavoriteButton(d, cur_item_link, bid)
+        test_element.arrange_1(d, cur_item_link, cur_market)
+
+        cur_item_link = d.current_url
+        test_element = PageInstrumentLongPositionGoToPlatformButton(d, cur_item_link, bid)
+        test_element.full_test_with_tpi_v2(d, cur_language, cur_country, cur_role, cur_item_link)


### PR DESCRIPTION
в классе PageInstrumentLongPositionGoToPlatformButton для роли Auth использовался неподходящий метод для проверки открытия платформы в режиме TPI. В принципе если смотреть по матрице покрытия, то попадаются классы тестовых элементов на странице Page of trading instrument, которые должны проверять открытия платформы TPI, но написаны неправильно, например: PageInstrumentViewDetailedChartButton, PageInstrumentShortPositionGoToPlatformButton (последний я исправлю).