### PR TITLE
PlatformOverviewButton

### DIFF
--- a/pages/Elements/PlatformOverviewButton.py
+++ b/pages/Elements/PlatformOverviewButton.py
@@ -8,6 +8,7 @@ from src.src import CapitalComPageSrc, InvestmateApp
 
 from datetime import datetime
 import allure
+import time
 
 from pages.common import Common
 from pages.base_page import BasePage
@@ -53,6 +54,7 @@ class PlatformOverviewButton(BasePage):
 
         if not self.current_page_is(link):
             self.link = InvestmateApp.URL
+            time.sleep(2)
             self.open_page()
 
         # Check that present and visible block


### PR DESCRIPTION
PlatformOverviewButton:

1. added time.slip before open_page

Hа параметрах En, CYSEC(de), NoAuth - в стектрейсах выдает TimeoutException, что время ожидания вышло. Поэтому добавляю время ожидания при открытии страницы и тогда, при повторном прогоне тестов, соответствующей ошибки уже не обнаруживается.  