### PR TITLE
ready to review: bug_617

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -358,6 +358,16 @@ def init_remote_driver_chrome():
             service=ChromeService(driver_path),
             options=chrome_options
         )
+
+        # Принудительное удаление информации о безголовом режиме из --user-agent - используется для обхода капчи
+        user_agent = driver.execute_script("return navigator.userAgent;")
+        user_agent = user_agent.replace("Headless", "")
+        chrome_options.add_argument(f"--user-agent={user_agent}")
+        driver = webdriver.Chrome(
+            service=ChromeService(driver_path),
+            options=chrome_options
+        )
+
     elif variant == 2:
         # chrome_version = "115.0.5790.102" - версия chromium CFT
         # chrome_version = "115.0.5790.114"

--- a/tests/US_55_ReTestsManual/artemdashkov/US_55-artemdashkov_ReTestsManual_test.py
+++ b/tests/US_55_ReTestsManual/artemdashkov/US_55-artemdashkov_ReTestsManual_test.py
@@ -1546,12 +1546,6 @@ class TestManualDetected:
             False, True
         )
         # Arrange
-        user_agent = d.execute_script("return navigator.userAgent;")
-        print(user_agent)
-        pytest.skip("Промежуточная версия")
-
-        # chrome_options.add_argument("--disable-blink-features=AutomationControlled")
-        # chrome_options.add_argument("--user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.3")
 
         cur_item_link = apply_preconditions_to_link(d, cur_language, cur_country, cur_role, cur_login, cur_password)
 


### PR DESCRIPTION
Принудительное удаление информации о безголовом режиме из --user-agent, используется для обхода капчи. При локальном прогоне после изменения кода капча не появляется.